### PR TITLE
feat(graphql-react-ws): syncStore opt-out for callback-only subscriptions

### DIFF
--- a/.changeset/sync-store-opt-out.md
+++ b/.changeset/sync-store-opt-out.md
@@ -1,0 +1,5 @@
+---
+'@soundxyz/graphql-react-ws': patch
+---
+
+Add `syncStore` option to `useSubscription` (default `true`). Set `syncStore: false` when consuming events only via `onData`/`onError` to skip mirroring each result into the valtio store — avoiding a React re-render of the calling component on every subscription frame. Important for high-frequency fan-out (e.g. chat reactions). Returned `data`/`error` do not update while `syncStore` is `false`.

--- a/packages/graphql-react-ws/README.md
+++ b/packages/graphql-react-ws/README.md
@@ -97,7 +97,9 @@ const { data, error, store } = graphql.useSubscription({
     into the valtio store so returned `data`/`error` stay reactive. Set to
     `false` for callback-only consumers (e.g. writing into an external cache)
     to avoid re-rendering the calling component on every subscription frame.
-    Returned `data`/`error` do not update while `syncStore` is `false`.
+    Returned `data`/`error` stay `null` and do not track the store while
+    `syncStore` is `false`. The mount also does not subscribe to the shared
+    store via `useSnapshot`, so peer writers cannot re-render it either.
 
 - **Returns:**
   - `data`: Latest subscription data.

--- a/packages/graphql-react-ws/README.md
+++ b/packages/graphql-react-ws/README.md
@@ -79,6 +79,9 @@ const { data, error, store } = graphql.useSubscription({
     /* handle errors */
   },
   enabled: true, // optional, default true
+  // Optional. Default true. Set false when you only use onData/onError and
+  // don't want each frame to re-render this component via the valtio store.
+  syncStore: true,
 });
 ```
 
@@ -90,6 +93,11 @@ const { data, error, store } = graphql.useSubscription({
   - `onError`: (optional) Callback for errors.
   - `initialData`: (optional) Initial data for the store.
   - `enabled`: (optional) Whether the subscription is active.
+  - `syncStore`: (optional, default `true`) When `true`, mirrors each result
+    into the valtio store so returned `data`/`error` stay reactive. Set to
+    `false` for callback-only consumers (e.g. writing into an external cache)
+    to avoid re-rendering the calling component on every subscription frame.
+    Returned `data`/`error` do not update while `syncStore` is `false`.
 
 - **Returns:**
   - `data`: Latest subscription data.

--- a/packages/graphql-react-ws/src/client.test.ts
+++ b/packages/graphql-react-ws/src/client.test.ts
@@ -191,4 +191,37 @@ describe('syncStore', () => {
     await waitFor(() => expect(onDataFalse).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(reactive.current.data?.data).toEqual({ foo: 'shared' }));
   });
+
+  it('does not re-render a syncStore:false mount when a syncStore:true peer writes the store', async () => {
+    sinks = [];
+
+    const { useSubscription } = GraphQLReactWS({
+      graphqlWsOptions: { url: 'wss://example.test' } as any,
+    });
+
+    let callbackOnlyRenders = 0;
+
+    renderHook(() => {
+      callbackOnlyRenders += 1;
+      return useSubscription({
+        query: TestSubscription,
+        syncStore: false,
+      });
+    });
+
+    const { result: reactive } = renderHook(() =>
+      useSubscription({
+        query: TestSubscription,
+        syncStore: true,
+      }),
+    );
+
+    await waitFor(() => expect(sinks).toHaveLength(1));
+    const rendersAfterMount = callbackOnlyRenders;
+
+    sinks[0]!.next({ data: { foo: 'peer-write' } });
+
+    await waitFor(() => expect(reactive.current.data?.data).toEqual({ foo: 'peer-write' }));
+    expect(callbackOnlyRenders).toBe(rendersAfterMount);
+  });
 });

--- a/packages/graphql-react-ws/src/client.test.ts
+++ b/packages/graphql-react-ws/src/client.test.ts
@@ -56,3 +56,105 @@ describe('fatal per-operation transport error', () => {
     await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
   });
 });
+
+describe('syncStore', () => {
+  it('still delivers onData when syncStore is false', async () => {
+    sinks = [];
+
+    const { useSubscription } = GraphQLReactWS({
+      graphqlWsOptions: { url: 'wss://example.test' } as any,
+    });
+
+    const onData = vi.fn();
+
+    renderHook(() =>
+      useSubscription({
+        query: TestSubscription,
+        onData,
+        syncStore: false,
+      }),
+    );
+
+    await waitFor(() => expect(sinks).toHaveLength(1));
+
+    sinks[0]!.next({ data: { foo: 'bar' } });
+
+    await waitFor(() => expect(onData).toHaveBeenCalledTimes(1));
+    expect(onData.mock.calls[0]![0]).toMatchObject({ data: { foo: 'bar' } });
+  });
+
+  it('does not re-render the caller on each frame when syncStore is false', async () => {
+    sinks = [];
+
+    const { useSubscription } = GraphQLReactWS({
+      graphqlWsOptions: { url: 'wss://example.test' } as any,
+    });
+
+    const onData = vi.fn();
+    let renderCount = 0;
+
+    renderHook(() => {
+      renderCount += 1;
+      return useSubscription({
+        query: TestSubscription,
+        onData,
+        syncStore: false,
+      });
+    });
+
+    await waitFor(() => expect(sinks).toHaveLength(1));
+    const rendersAfterMount = renderCount;
+
+    sinks[0]!.next({ data: { foo: 'one' } });
+    sinks[0]!.next({ data: { foo: 'two' } });
+    sinks[0]!.next({ data: { foo: 'three' } });
+
+    await waitFor(() => expect(onData).toHaveBeenCalledTimes(3));
+    expect(renderCount).toBe(rendersAfterMount);
+  });
+
+  it('updates returned data and re-renders when syncStore is true (default)', async () => {
+    sinks = [];
+
+    const { useSubscription } = GraphQLReactWS({
+      graphqlWsOptions: { url: 'wss://example.test' } as any,
+    });
+
+    const { result } = renderHook(() =>
+      useSubscription({
+        query: TestSubscription,
+      }),
+    );
+
+    await waitFor(() => expect(sinks).toHaveLength(1));
+    expect(result.current.data).toBeNull();
+
+    sinks[0]!.next({ data: { foo: 'live' } });
+
+    await waitFor(() => expect(result.current.data?.data).toEqual({ foo: 'live' }));
+  });
+
+  it('still reaches onError when syncStore is false', async () => {
+    sinks = [];
+
+    const { useSubscription } = GraphQLReactWS({
+      graphqlWsOptions: { url: 'wss://example.test' } as any,
+    });
+
+    const onError = vi.fn();
+
+    renderHook(() =>
+      useSubscription({
+        query: TestSubscription,
+        onError,
+        syncStore: false,
+      }),
+    );
+
+    await waitFor(() => expect(sinks).toHaveLength(1));
+
+    sinks[0]!.error(new Error('operation terminated by server'));
+
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+  });
+});

--- a/packages/graphql-react-ws/src/client.test.ts
+++ b/packages/graphql-react-ws/src/client.test.ts
@@ -157,4 +157,38 @@ describe('syncStore', () => {
 
     await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
   });
+
+  it('does not let a syncStore:false peer starve a syncStore:true peer of store writes', async () => {
+    sinks = [];
+
+    const { useSubscription } = GraphQLReactWS({
+      graphqlWsOptions: { url: 'wss://example.test' } as any,
+    });
+
+    const onDataFalse = vi.fn();
+
+    // Mount the callback-only listener first so it is first in the broadcast
+    // Set and processes the shared result object before the reactive peer.
+    renderHook(() =>
+      useSubscription({
+        query: TestSubscription,
+        onData: onDataFalse,
+        syncStore: false,
+      }),
+    );
+
+    const { result: reactive } = renderHook(() =>
+      useSubscription({
+        query: TestSubscription,
+        syncStore: true,
+      }),
+    );
+
+    await waitFor(() => expect(sinks).toHaveLength(1));
+
+    sinks[0]!.next({ data: { foo: 'shared' } });
+
+    await waitFor(() => expect(onDataFalse).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(reactive.current.data?.data).toEqual({ foo: 'shared' }));
+  });
 });

--- a/packages/graphql-react-ws/src/client.ts
+++ b/packages/graphql-react-ws/src/client.ts
@@ -459,6 +459,18 @@ export function GraphQLReactWS<ConnectionInitPayload extends Record<string, unkn
 
   const subscriptionStores: Map<string, SubscriptionStore<StringDocumentNode>> = new Map();
 
+  /**
+   * Stable inert proxy for `useProxySnapshot` when `syncStore` is false.
+   * Callback-only mounts must not subscribe to the shared subscription store —
+   * otherwise a `syncStore: true` peer (or `setSubscriptionData`) writing that
+   * store would still re-render them via valtio.
+   */
+  const inertSubscriptionSnapshot = proxy({
+    data: null,
+    error: null,
+    ref: ref({ current: null }),
+  });
+
   function getSubscriptionStore<Doc extends StringDocumentNode>({
     query,
     variables,
@@ -504,10 +516,11 @@ export function GraphQLReactWS<ConnectionInitPayload extends Record<string, unkn
      * `useSnapshot`.
      *
      * Set to `false` when you only consume events through `onData`/`onError`
-     * (e.g. writing into an external cache). Skipping the store write avoids a
-     * React re-render of the calling component on every subscription frame —
-     * important for high-frequency fan-out. Returned `data`/`error` will not
-     * update while `syncStore` is `false`.
+     * (e.g. writing into an external cache). Skipping the store write — and
+     * unsubscribing this mount from the shared store snapshot — avoids a
+     * React re-render of the calling component on every subscription frame,
+     * including when a `syncStore: true` peer updates the same store.
+     * Returned `data`/`error` stay `null` while `syncStore` is `false`.
      */
     syncStore = true,
   }: {
@@ -530,12 +543,16 @@ export function GraphQLReactWS<ConnectionInitPayload extends Record<string, unkn
       initialData,
     });
 
-    if (initialData && !store.data) {
+    if (syncStore && initialData && !store.data) {
       store.data = initialData;
       store.ref.current = initialData;
     }
 
-    const { data, error } = useProxySnapshot(store);
+    // Snapshot the shared store only when this mount opts into store sync.
+    // Otherwise track an inert proxy so peer writes cannot re-render us.
+    const { data, error } = useProxySnapshot(
+      syncStore ? store : (inertSubscriptionSnapshot as SubscriptionStore<Doc>),
+    );
 
     const onDataCallback = useStableCallback<OnData<Doc>>(resultWithData => {
       if (!onData) return;
@@ -637,8 +654,8 @@ export function GraphQLReactWS<ConnectionInitPayload extends Record<string, unkn
     }, [stableVariables, enabled, query, syncStore]);
 
     return {
-      data,
-      error,
+      data: syncStore ? data : null,
+      error: syncStore ? error : null,
       store,
     };
   }

--- a/packages/graphql-react-ws/src/client.ts
+++ b/packages/graphql-react-ws/src/client.ts
@@ -577,6 +577,11 @@ export function GraphQLReactWS<ConnectionInitPayload extends Record<string, unkn
                   data: result.data,
                 };
 
+                // Only syncStore consumers participate in the shared-store
+                // dedup (`store.ref`). A syncStore:false peer must not advance
+                // the ref — otherwise it can mark this broadcast result as
+                // "already applied" before a syncStore:true peer writes
+                // `data`/`error`, leaving that peer's returned values stale.
                 if (syncStore && store.ref.current !== result) {
                   store.data = resultWithData;
 
@@ -599,7 +604,9 @@ export function GraphQLReactWS<ConnectionInitPayload extends Record<string, unkn
                 onErrorCallback(resultWithError);
               }
 
-              store.ref.current = result;
+              if (syncStore) {
+                store.ref.current = result;
+              }
             }
           } catch (err) {
             // A fatal per-operation error (the server terminates just this

--- a/packages/graphql-react-ws/src/client.ts
+++ b/packages/graphql-react-ws/src/client.ts
@@ -497,6 +497,19 @@ export function GraphQLReactWS<ConnectionInitPayload extends Record<string, unkn
     initialData = null,
 
     enabled = true,
+
+    /**
+     * When `true` (default), each result is mirrored into the valtio
+     * subscription store so `data`/`error` from this hook stay reactive via
+     * `useSnapshot`.
+     *
+     * Set to `false` when you only consume events through `onData`/`onError`
+     * (e.g. writing into an external cache). Skipping the store write avoids a
+     * React re-render of the calling component on every subscription frame —
+     * important for high-frequency fan-out. Returned `data`/`error` will not
+     * update while `syncStore` is `false`.
+     */
+    syncStore = true,
   }: {
     query: Doc;
     onData?: OnData<Doc>;
@@ -505,6 +518,8 @@ export function GraphQLReactWS<ConnectionInitPayload extends Record<string, unkn
     initialData?: ExecutionResultWithData<ResultOf<Doc>> | null;
 
     enabled?: boolean;
+
+    syncStore?: boolean;
   } & (VariablesOf<Doc> extends Record<string, never>
     ? { variables?: undefined }
     : { variables: VariablesOf<Doc> | false })) {
@@ -562,7 +577,7 @@ export function GraphQLReactWS<ConnectionInitPayload extends Record<string, unkn
                   data: result.data,
                 };
 
-                if (store.ref.current !== result) {
+                if (syncStore && store.ref.current !== result) {
                   store.data = resultWithData;
 
                   if (!result.errors && store.error) {
@@ -579,7 +594,7 @@ export function GraphQLReactWS<ConnectionInitPayload extends Record<string, unkn
                   errors: result.errors,
                 };
 
-                if (store.ref.current !== result) store.error = resultWithError;
+                if (syncStore && store.ref.current !== result) store.error = resultWithError;
 
                 onErrorCallback(resultWithError);
               }
@@ -598,7 +613,9 @@ export function GraphQLReactWS<ConnectionInitPayload extends Record<string, unkn
               errors: Array.isArray(err) ? err : [err],
             } as ExecutionResultWithErrors<ResultOf<Doc>>;
 
-            store.error = resultWithError;
+            if (syncStore) {
+              store.error = resultWithError;
+            }
 
             onErrorCallback(resultWithError);
           }
@@ -610,7 +627,7 @@ export function GraphQLReactWS<ConnectionInitPayload extends Record<string, unkn
       return () => {
         subscription.abortController.abort();
       };
-    }, [stableVariables, enabled, query]);
+    }, [stableVariables, enabled, query, syncStore]);
 
     return {
       data,


### PR DESCRIPTION
## Summary

- Adds `syncStore` to `useSubscription` (default `true`, backwards compatible).
- When `syncStore: false`, results are delivered only via `onData`/`onError` and are **not** mirrored into the valtio store — so `useSnapshot` does not re-render the calling component on every frame.
- Motivated by high-frequency GraphQL subscriptions (e.g. Vault chat reactions / typing digests) that write into an external cache and never read returned `data`/`error`.

## Why

Today every subscription frame does `store.data = …` + `useProxySnapshot(store)`, which forces a React re-render of whatever component called the hook — even if the app only uses `onData`. Under chat fan-out that re-renders entire channel shells.

App-side workarounds (null-rendering leaf components) work but push the cost of a library default onto every consumer. This flag fixes it at the source.

## API

```ts
useSubscription({
  query,
  variables,
  onData,
  onError,
  /** @default true */
  syncStore: false, // callback-only; no per-frame re-render
});
```

Returned `data`/`error` do not update while `syncStore` is `false`.

## Test plan

- [x] Unit tests: `onData` still fires with `syncStore: false`
- [x] Unit tests: caller render count does not increase across multiple frames when `syncStore: false`
- [x] Unit tests: default `syncStore: true` still updates returned `data`
- [x] Unit tests: fatal `onError` still fires with `syncStore: false`
- [ ] After publish (`@soundxyz/graphql-react-ws` patch), Vault can pass `syncStore: false` from `useResilientSubscription` and optionally remove the `*Subscriber` leaf components

## Deployment considerations

- Patch release via changesets.
- Consumers must bump `@soundxyz/graphql-react-ws` and opt in with `syncStore: false` to benefit — no behavior change at default.

## Other call outs

N/A


Made with [Cursor](https://cursor.com)